### PR TITLE
FontAwesomeのバージョン及びbrandsのみ使用するように修正

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -25,7 +25,11 @@
     <link rel="stylesheet" href="{{ site.baseurl }}/css/index.css" />
     <link
       rel="stylesheet"
-      href="https://use.fontawesome.com/releases/v5.6.3/css/all.css"
+      href="https://use.fontawesome.com/releases/v5.12.0/css/fontawesome.css"
+    />
+    <link
+      rel="stylesheet"
+      href="https://use.fontawesome.com/releases/v5.12.0/css/brands.css"
     />
 
     <title>おめシスのホームページ</title>


### PR DESCRIPTION
- バージョンを v5.6.3 -> v5.12.0 に
- ブランドアイコンしか使用していないためallではなくbrandsを使用するように