### PR TITLE
グラデーションのカラーをテーマカラーに寄せてみました

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -104,7 +104,7 @@ i.fab {
 .links {
   padding: 230px 80px;
   background: url(../images/omesis.png) top center no-repeat,
-    linear-gradient(to left, blue, red);
+    linear-gradient(to left, #de7072, #7995f7);
   background-size: cover;
   text-align: center;
   text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
@@ -117,7 +117,7 @@ i.fab {
 @media screen and (max-width: 700px) {
   .links {
     padding: 40px;
-    background: linear-gradient(to left, blue, red);
+    background: linear-gradient(to left, #de7072, #7995f7);
   }
 }
 
@@ -162,7 +162,7 @@ i.fab {
 }
 
 .share-button {
-  background: linear-gradient(to right, #3b26b1, #962c6a);
+  background: linear-gradient(to left, #3b26b1, #962c6a);
   border-radius: 24px;
   box-shadow: 0 0 8px #00000050;
   padding: 16px 24px;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- タイトルは変更の内容が他の人にも伝わるように1行でまとめる。 -->

## 変更内容
グラデーション部分の青赤を反転し、テーマカラーに寄せました。

## 補足
赤
`#de7072`
青
`#7995f7`

それぞれ、 [upd8 の宣材写真](https://upd8.jp/uploadimage/2018/05/omesis_up02.png)からピックしました

![image](https://user-images.githubusercontent.com/25493569/71106691-1e7d5d00-2203-11ea-9f1b-438023e75dae.png)
変更後
![image](https://user-images.githubusercontent.com/25493569/71106715-2937f200-2203-11ea-9b89-64a5f5b81ef9.png)
