### PR TITLE
ボタン・リンクにマウスオーバ時のエフェクトを追加

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -155,7 +155,9 @@ figure.hero__bg {
     background: linear-gradient(to left, #de7072, #7995f7);
   }
 }
-
+.links a:hover {
+  color: #06ffd2;
+}
 .profiles {
   display: flex;
   justify-content: center;
@@ -207,8 +209,10 @@ figure.hero__bg {
   text-decoration: none;
   transition: box-shadow 0.25s;
 }
-.share-button:hover {
+a.share-button:hover {
+  color: white;
   box-shadow: 0 0 24px #00000050;
+  background: linear-gradient(to left, #962c6a, #3b26b1);
 }
 
 /*


### PR DESCRIPTION
## 変更内容

ボタン・リンクにマウスオーバ時のエフェクトを追加
マウスオーバ時に反応がないと、PCで閲覧している人がリンクと認識できない為

## 補足
![video](https://user-images.githubusercontent.com/5664171/71134669-77201a80-2242-11ea-9ce8-1b514bd885cb.gif)

