### PR TITLE
隠しリンクの表示位置修正

### DIFF
--- a/alpha.html
+++ b/alpha.html
@@ -120,7 +120,7 @@
         <div class="box">
           <a
             class="share-button"
-            href="https://twitter.com/intent/tweet?text=%23あるブラはいいぞ &url=https://omegasisters.github.io/homepage"
+            href="https://twitter.com/intent/tweet?text=%23あるブラはいいぞ"
           >
             #あるブラはいいぞ
           </a>

--- a/index.html
+++ b/index.html
@@ -214,12 +214,12 @@
             #おめシスはいいぞ
           </a>
         </div>
+        <div id="preact"></div>
         <div class="c-alpha">
           <a class="c-alpha__link" href="./alpha.html">
             α
           </a>
         </div>
-        <div id="preact"></div>
       </div>
 
       <div


### PR DESCRIPTION
## 変更内容

- 隠しリンクの位置がモデル表示している部分より上に来ていたので画面最下部になるよう修正。
  - ローカルで表示されていなかったので見落としたため。
- また、隠しページからのシェアの場合はURLを抜くようにした
## 補足

五月雨で申し訳ない！