### PR TITLE
Docker起動時のWORKDIRを指定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM node:alpine
-COPY . /
+
+WORKDIR /omegasisters-webpage
+ADD . /omegasisters-webpage
+
 RUN yarn
 ENTRYPOINT ["yarn", "start:docker"]


### PR DESCRIPTION
## 変更内容

コンテナ内のルートディレクトリにアプリケーションファイルが展開されていたので `WORKDIR` を利用するように変更しました

### before
```
$ docker-compose exec omegasisters-webpage ls             
404.html              images                proc              
Dockerfile            index.html            root              
README.md             index.js              run               
__tests__             jest.config.js        sbin              
alpha.html            lib                   server.js         
assets                manifest.webmanifest  srv               
bin                   media                 sw.js             
css                   mnt                   sys               
dev                   node_modules          tmp               
docker-compose.yml    opt                   tsconfig.json     
dotnet                package-lock.json     usr               
etc                   package.json          var               
home                  preact                web_modules       
homepage              preact_build          yarn.lock    
```

### after

```
$ docker-compose exec omegasisters-webpage ls 
404.html              homepage              preact
Dockerfile            images                preact_build
README.md             index.html            server.js
__tests__             index.js              sw.js
alpha.html            jest.config.js        tsconfig.json
assets                manifest.webmanifest  web_modules
css                   node_modules          yarn.lock
docker-compose.yml    package-lock.json
dotnet                package.json
```