### PR TITLE
package.jsonに設定を追加。license: UNLICENSED, private: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "https://omegasisters.github.io/homepage",
   "version": "0.0.1",
   "license": "UNLICENSED",
+  "private": true,
   "scripts": {
     "build": "npm run pika && npm run pika:dev && npm run ts",
     "dev": "browser-sync start --server --files '*.js' .",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "omegasisters-homepage",
   "description": "https://omegasisters.github.io/homepage",
   "version": "0.0.1",
+  "license": "UNLICENSED",
   "scripts": {
     "build": "npm run pika && npm run pika:dev && npm run ts",
     "dev": "browser-sync start --server --files '*.js' .",


### PR DESCRIPTION
## 変更内容

`yarn install`した際にwarningが出て気になるので、package.jsonにlicenseフィールドを追加し、`UNLICENSED`に設定しました。
ついでに、privateフィールドも追加し`true`に設定しました。

## 補足

![3  LiquidCarbon (docker-compose) 2019-12-23 20-18-09](https://user-images.githubusercontent.com/134377/71355414-50efd700-25c2-11ea-9227-ea865464adc0.png)

### package.jsonのlicense, privateフィールドについて

> Finally, if you do not wish to grant others the right to use a private or unpublished package under any terms:
> 
> ```
> { "license": "UNLICENSED" }
> ```
> Consider also setting "private": true to prevent accidental publication.
> https://docs.npmjs.com/files/package.json#license

publicリポジトリでみんながいじってるしUNLICENSEDで良いのかちょっと気になるけど、このコードを利用してみんながホームページを公開する想定では無いと思うので。