### PR TITLE
初心者向けすごい面白い動画のリストに、マウスホバーでタイトル表示

### DIFF
--- a/assets/js/ytplaylist.js
+++ b/assets/js/ytplaylist.js
@@ -17,7 +17,13 @@ const loadPlayList = (id, dom) => {
       image.dataset.src = item.snippet.thumbnails.high.url;
       image.className = 'lazy';
 
+      const span = document.createElement('span');
+      span.textContent = item.snippet.title
+      span.className = 'video-title'
+
       link.appendChild(image);
+      link.appendChild(span);
+
       dom.appendChild(link);
     });
 

--- a/css/index.css
+++ b/css/index.css
@@ -220,14 +220,32 @@ a:hover {
 .playlist .videos {
   display: flex;
   overflow-x: auto;
+  overflow-y: hidden;
 }
 .videos .video-link {
   display: block;
   margin: 0 10px;
+  position: relative;
+  height: 240px;
 }
 .videos .video-link img {
   width: 320px;
+  height: 240px;
 }
+.videos .video-link .video-title {
+  width: 100%;
+  background: rgba(0,0,0,0.7);
+  position: absolute;
+  opacity: 0;
+  transition: all 0.6s ease;
+  left: 0;
+  bottom: -50%;
+}
+.videos .video-link:hover .video-title {
+  bottom: 0;
+  opacity:1;
+}
+
 .videos::-webkit-scrollbar {
   width: 10px;
   height: 10px;

--- a/css/index.css
+++ b/css/index.css
@@ -261,8 +261,12 @@ a:hover {
     height: auto;
   }
 
+  .videos .video-link {
+    height: 150px;
+  }
   .videos .video-link img {
     width: 200px;
+    height: 150px;
   }
 }
 


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- タイトルは変更の内容が他の人にも伝わるように1行でまとめる。 -->

## 変更内容

マウスホバー時にタイトルが見れるといいなと思ったので入れてみました。

[![Image from Gyazo](https://i.gyazo.com/1214bd119aace854794decbd1d352db3.gif)](https://gyazo.com/1214bd119aace854794decbd1d352db3)

<!-- 何故変更したか、これが取り込まれると何が嬉しいか、何が解決されるのか、など詳細な内容を記載 -->

## 補足

`npm start`で動作確認しました
マウスホバーに関してなのでPCのみで動きます（スマホだとタップ後にタイトルが出てくるかも？）
レイアウトが崩れに関してだけスマホもchrome dev toolで確認しています。

<!-- レビューをする際に特に見てほしい点、懸念・注意点、など 画像とかあるとわかりやすいかも！ -->
