### PR TITLE
ヘッダーリンクでのスクロール時のヘッダーかぶりを修正

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -60,7 +60,8 @@ body {
 h2.section_title {
   /* ヘッダからのジャンプ用タイトル */
   margin-bottom: 20px;
-  padding-top: 6vh;
+  margin-top: -50px;
+  padding-top: calc(50px + 6vh);
 }
 
 .box {
@@ -256,7 +257,7 @@ a:hover {
 }
 .firstview .video_box {
   padding: 4vw;
-  background-color: rgba(255,255,255,0.2);
+  background-color: rgba(255, 255, 255, 0.2);
   width: 60%;
   border-radius: 1vw;
 }


### PR DESCRIPTION
## 変更内容
- スティッキーヘッダー部分を考慮してスクロールするように修正
ヘッダー部のリンクをクリックしてスクロールするとき、スティッキーヘッダー部分がかぶさってスクロールされてしまうのを修正しました。

## 確認事項
- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [ ] 破壊的な変更を行った場合、影響範囲をもう一度確認した。

## 補足
![Dec-24-2019 23-33-48](https://user-images.githubusercontent.com/20788898/71416895-e617cc00-26a5-11ea-9eaf-8b19131c7bda.gif)

