### PR TITLE
#193 slickのスマホ用処理を追加

### DIFF
--- a/assets/js/ytplaylist.js
+++ b/assets/js/ytplaylist.js
@@ -32,12 +32,28 @@ const loadPlayList = (id, dom) => {
         dom.appendChild(link);
       });
 
-      $('.' + dom.className).slick({
-        autoplay: true,
-        autoplaySpeed: 5000,
-        dots: true,
-        slidesToShow: 3,
-      });
+      var IsDevice = DeviceName => (navigator.userAgent.indexOf(DeviceName) > 0);
+
+      var isSmartphone = (IsDevice('iPhone') || IsDevice('iPod') || IsDevice('Android') && IsDevice('Movile'));
+
+      var isTablet = (!isSmartphone && IsDevice('Android') || IsDevice('iPad'));
+
+      if(isSmartphone || isTablet)
+      {
+        $('.' + dom.className).slick({
+          autoplay: true,
+          autoplaySpeed: 4000,
+          dots: false,
+          slidesToShow: 1,
+        });
+      } else {
+        $('.' + dom.className).slick({
+          autoplay: true,
+          autoplaySpeed: 4000,
+          dots: true,
+          slidesToShow: 3,
+        });
+      }
 
       lazyLoad();
     });


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- タイトルは変更の内容が他の人にも伝わるように1行でまとめる。 -->

## 変更内容

タブレットやスマートフォンなどでのプレイリストの表示方法について, 以下の点を変更.

- 表示動画数を1つに制限

- 動画下に表示されていたドットの描画がおかしくなることを確認していたため, 非表示に変更

PC版についての変更はありません.

<!-- 何故変更したか、これが取り込まれると何が嬉しいか、何が解決されるのか、など詳細な内容を記載 -->

## 確認事項

<!-- PRを作成するとチェックボックスになります、もしくは [x] にするとチェック状態になります。 -->

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [ ] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [ ] 破壊的な変更を行った場合、影響範囲をもう一度確認した。

## 補足

<!-- レビューをする際に特に見てほしい点、懸念・注意点、など 画像とかあるとわかりやすいかも！ -->
