### PR TITLE
モバイルで動画一覧の左右のボタンをタップした時に、アウトラインを表示しないようにする

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -459,6 +459,7 @@ a:hover {
   background-image: none;
   width: 28px;
   height: 86px;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 .swiper-button-prev:after {
   font-family: 'Font Awesome 5 Free';
@@ -474,6 +475,11 @@ a:hover {
   font-size: 48px;
   color: #007aff;
   text-shadow: -4px 4px 6px #8f8fff;
+}
+
+.swiper-button-prev:focus,
+.swiper-button-next:focus {
+  outline: none;
 }
 
 .swiper-container-3d .swiper-slide-shadow-left,


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- タイトルは変更の内容が他の人にも伝わるように1行でまとめる。 -->

## 変更内容
モバイルで「⭐【初心者向け】すごい面白い動画」にある次の動画、前の動画を表示するためボタンをタップした時に、ボタンのアウトラインが表示されてしまっているため表示しないようにしました。

### 修正前
![before](https://user-images.githubusercontent.com/1418311/71781010-1435ce00-300d-11ea-9d11-f10239d9e168.gif)

### 修正後
![after](https://user-images.githubusercontent.com/1418311/71781012-18fa8200-300d-11ea-81aa-8980b8180943.gif)

PC版Safari、Chrome、モバイルのSafari、Chromeで確認済みです。
## 確認事項

<!-- PRを作成するとチェックボックスになります、もしくは [x] にするとチェック状態になります。 -->

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。

## 補足

<!-- レビューをする際に特に見てほしい点、懸念・注意点、など 画像とかあるとわかりやすいかも！ -->
