### PR TITLE
おめがってるー!?を動画の字幕風にしてみた

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css?family=Kosugi+Maru&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Kosugi+Maru|M+PLUS+1p:900&display=swap');
 
 * {
   margin: 0;
@@ -281,15 +281,32 @@ a:hover {
   }
 }
 .firstview .do-omega {
-  font-weight: bold;
-  margin-top: 1em;
-  letter-spacing: 6px;
-  text-shadow: 4px 4px 6px #ffaeae, -4px 4px 6px #8f8fff;
-  font-size: 3em;
+  margin: 1rem 0;
+  font-family: 'M PLUS 1p', -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-weight: 900;
+  padding-right: 0.3rem;
+  letter-spacing: -0.9rem;
+  font-size: 7rem;
+  line-height: initial;
+  background: linear-gradient(
+    to bottom,
+    rgb(254, 127, 126),
+    rgb(254, 127, 126) 50%,
+    rgb(47, 168, 249) 53%
+  );
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: white;
+  -webkit-text-fill-color: transparent;
+  -webkit-text-stroke: 0.4rem whitesmoke;
 }
 @media screen and (max-width: 700px) {
   .firstview .do-omega {
-    font-size: 1.4em;
+    padding-right: 0.1rem;
+    letter-spacing: -0.3rem;
+    font-size: 2.1rem;
+    -webkit-text-stroke-width: 0.15rem;
   }
 }
 .firstview .video_box {

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@ MMMMMMMMMMMMMMMMMMMMMMMMMNNmaggkwkkXuuVVXuuXXkkXuuZuXVuVCXwkwQggggNNMMMMMMMMMMMM
 
         <section class="section firstview">
           <h1 class="section_title do-omega" id="section_firstview">
-            おめがってるー？！
+            おめがってるー!?
           </h1>
           <div class="box">
             <i class="fab fa-youtube"></i>


### PR DESCRIPTION
## 変更内容

おめがってるー!?を動画の字幕風にしてみました。
動画の様に2重のアウトラインは頑張ってみたけど実現できなかったので、白の縁取りのみです。
アウトラインで字を潰さない為、元よりテキストサイズも大きくなってます。

* Pros
  * インパクトがある。
  * 動画に似せたスタイルにできる。
* Cons
  * オシャレ感が減る。
  * Google FontsでM+PLUS+1p:900を追加したので、その分通信量が増える。

## 確認事項

<!-- PRを作成するとチェックボックスになります、もしくは [x] にするとチェック状態になります。 -->

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [ ] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。

## 補足

<!-- レビューをする際に特に見てほしい点、懸念・注意点、など 画像とかあるとわかりやすいかも！ -->

PRを出した理由は、代表的なセリフが動画と同じ見た目になったらいいなと思ったからです。
まったく同じという所まではやりきれなかったですが、どうでしょうか？
少なくとも変な見た目ではない所までは、持って行けたかなと思ってはいるんですが、自分では目が慣れてしまって違和感に気が付けなくなっているかもです。

なお、カラーコードは https://youtu.be/DChL3IayER0?t=2 からスポイトツールで採取しました。

![おめシスのホームページ _ 第１回おめシスのホームページをプルリクだけで更新していったらどうなるの？企画 - Mozilla Firefox 2020-01-07 20 47 59](https://user-images.githubusercontent.com/134377/71893448-0d36c900-318f-11ea-9ac5-8ea16de944e3.png)

![おめシスのホームページ _ 第１回おめシスのホームページをプルリクだけで更新していったらどうなるの？企画 - Mozilla Firefox 2020-01-07 20 42 27](https://user-images.githubusercontent.com/134377/71893191-3e62c980-318e-11ea-89af-c8f1d0187e69.png)