### PR TITLE
診断結果ページのタイトルを中央寄せにする

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -157,6 +157,7 @@ a:hover {
 
 .hero .logo,
 .guide_for_scroll {
+  text-align: center;
   margin: 0;
   padding: 0;
   font-size: 140px;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- タイトルは変更の内容が他の人にも伝わるように1行でまとめる。 -->

## 変更内容
おめが診断の結果をモバイルで表示すると、「診断結果」の文字が左に寄っていて不自然だったので中央寄せしました。（詳しくは添付画像を参照）
診断結果ページはおめがレイ、おめがリオ、うんちゃんの3ページでそれぞれ画像のように
中央寄せされます。
その他影響のあるおめシスのトップページとあるふぁブラザーズのトップページも含め、
PC版とモバイル版のSafariで表示が崩れないことを確認済みです。

### 変更前
<img width="407" alt="スクリーンショット 2020-01-08 23 40 42" src="https://user-images.githubusercontent.com/1418311/71988838-f4541380-3273-11ea-9a18-688974109bd5.png">

### 変更後
<img width="401" alt="スクリーンショット 2020-01-08 23 40 29" src="https://user-images.githubusercontent.com/1418311/71988860-fc13b800-3273-11ea-9c86-993d9c93966e.png">

<!-- 何故変更したか、これが取り込まれると何が嬉しいか、何が解決されるのか、など詳細な内容を記載 -->

## 確認事項

<!-- PRを作成するとチェックボックスになります、もしくは [x] にするとチェック状態になります。 -->

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。

## 補足

<!-- レビューをする際に特に見てほしい点、懸念・注意点、など 画像とかあるとわかりやすいかも！ -->
