### PR TITLE
診断ページの余白を調整

### DIFF
--- a/assets/css/sindan.css
+++ b/assets/css/sindan.css
@@ -45,6 +45,7 @@
   justify-content: flex-start;
   align-items: center;
   flex-direction: column;
+  padding-bottom: 80px;
 }
 
 .hero__logo_for_sindan {
@@ -53,7 +54,7 @@
 }
 
 .hero__logo_for_sindan_result {
-  margin-top: 8vh;
+  margin-top: 10vh;
 }
 
 .question-logo {
@@ -100,7 +101,7 @@
 }
 
 .desc-box {
-  margin-top: 200px;
+  margin-top: 150px;
   max-width: 800px;
   width: 90%;
   display: flex;

--- a/assets/css/sindan.css
+++ b/assets/css/sindan.css
@@ -49,6 +49,7 @@
 
 .hero__logo_for_sindan {
   margin-top: 0vh;
+  padding: 0 10px;
 }
 
 .hero__logo_for_sindan_result {


### PR DESCRIPTION
## 診断質問(スマホ時)の左右に隙間を追加

<img src="https://user-images.githubusercontent.com/39142850/72630275-5b20ad80-3995-11ea-8f3c-c32f5ee22d56.png" width=40%>

## 結果ページの上部に隙間を追加

<img src="https://user-images.githubusercontent.com/39142850/72630277-5c51da80-3995-11ea-8dca-cfce75392a30.png" width=40%>

## 結果の余白を少し小さく修正

<img src="https://user-images.githubusercontent.com/39142850/72630281-5d830780-3995-11ea-8752-7ed32b9780db.png" width=40%>

## 結果画面の下部が0だったので余白を追加

<img src="https://user-images.githubusercontent.com/39142850/72630288-5eb43480-3995-11ea-889b-db12f4ed902c.png" width=40%>

## 確認事項

<!-- PRを作成するとチェックボックスになります、もしくは [x] にするとチェック状態になります。 -->

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。