### PR TITLE
:bug: 404ページのcssがJekyllによって読み込まれていないのを修正(.nojekyll作成)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+node_modules
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM node:alpine
+
 WORKDIR /omegasisters-webpage
 
 # Cache node packages
-ADD package.json /omegasisters-webpage
-ADD yarn.lock /omegasisters-webpage
+# ADD doesn't make cache so you should use COPY
+COPY package.json yarn.lock ./
+
 RUN yarn
 
-ADD . /omegasisters-webpage
+COPY . .
 
 ENTRYPOINT ["yarn", "start:docker"]


### PR DESCRIPTION
## 変更内容

Github PagesデフォルトのJekyllを無効化することによって、404ページのcss(assets/404.css)が読み込まれない問題を解決する。

## 確認事項

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
- [x] 動作確認済みである。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。

