### PR TITLE
おめが診断ページにも右下にうんちゃん追加💩

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -704,7 +704,9 @@ a.share-button:hover {
 うんちゃん
 */
 .fukidashi {
-  display: inline-block;
+  display: flex;
+  align-items: center;
+  line-height: 1.5em;
   pointer-events: none;
   opacity: 0;
   transition: opacity 0.1s linear;
@@ -716,7 +718,6 @@ a.share-button:hover {
   padding: 0 5px;
   width: 100px;
   height: 100px;
-  line-height: 100px;
   text-align: center;
   color: #fff;
   font-size: 14px;

--- a/preact/sindan/SindanApp.tsx
+++ b/preact/sindan/SindanApp.tsx
@@ -130,6 +130,34 @@ const SindanApp: FunctionalComponent = () => {
           );
         })}
       </div>
+
+      {started == false && (
+        <a href="/homepage" className="c-unchan c-unchan--fixedBottom">
+          <div className="fukidashi" id="unchan_fukidashi">
+            ホームページに戻る
+          </div>
+          <div className="c-unchan__inner">
+            <div className="c-unchan__tsuno">
+              <div className="c-unchan__tsuno__inner"></div>
+            </div>
+            <div className="c-unchan__toguro c-unchan__toguro--top"></div>
+            <div className="c-unchan__toguro c-unchan__toguro--middle">
+              <div className="c-unchan__eye c-unchan__eye--left">
+                <div></div>
+              </div>
+              <div className="c-unchan__eye c-unchan__eye--right">
+                <div></div>
+              </div>
+            </div>
+            <div className="c-unchan__toguro c-unchan__toguro--bottom"></div>
+            <div className="c-unchan__mouth">
+              <div className="c-unchan__mouth__inner">
+                <div></div>
+              </div>
+            </div>
+          </div>
+        </a>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- タイトルは変更の内容が他の人にも伝わるように1行でまとめる。 -->

## 変更内容
おめが診断ページからホームページに戻りたい時に遷移ボタンがあるとユーザーに優しいかと思いホームページのトップにあるうんちゃんを診断ページにも追加しました。
うんちゃんをクリックするとホームページに戻ります。
<img width="1280" alt="スクリーンショット 2020-01-19 0 09 24" src="https://user-images.githubusercontent.com/32975158/72666385-047aa880-3a55-11ea-95b1-5bec14f39dfb.png">

おめが診断をはじめるとうんちゃんは非表示になります。最後まで診断をやりきってもらうため。
<img width="1280" alt="スクリーンショット 2020-01-19 0 09 30" src="https://user-images.githubusercontent.com/32975158/72666389-10666a80-3a55-11ea-91ca-ca0bef531d2c.png">

<!-- 何故変更したか、これが取り込まれると何が嬉しいか、何が解決されるのか、など詳細な内容を記載 -->

## 確認事項

<!-- PRを作成するとチェックボックスになります、もしくは [x] にするとチェック状態になります。 -->

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
  - 最新の master を取り込む方法
    - upstream に fork 元リポジトリを追加
      - `git remote add upstream git@github.com:omegasisters/homepage.git`
    - 現在のブランチに `upstream` の `master` を取り込む
      - `$ git pull --rebase upstream master`
  - おまけ
    - rebase 後に再度 `push` する場合、 `--force-with-lease` オプションをつける
      - `git push --force-with-lease origin <ブランチ名>`
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。

## 補足
作業中に金のうんちゃんが出てテンション上がりました💩！
<img width="1280" alt="スクリーンショット 2020-01-19 0 09 07" src="https://user-images.githubusercontent.com/32975158/72666395-23793a80-3a55-11ea-916e-c4e98728c7ee.png">

<!-- レビューをする際に特に見てほしい点、懸念・注意点、など 画像とかあるとわかりやすいかも！ -->
