### PR TITLE
code spell checkerで `omesis` がスペルミス扱いにならないようにしました

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.1",
+  "language": "en",
+  "words": [
+    "fukidashi",
+    "kosugi",
+    "maru",
+    "mochi",
+    "omegasisters",
+    "omesis",
+    "otohime",
+    "purupuru",
+    "rayrio",
+    "toguro",
+    "tsuno",
+    "unchan",
+    "unun",
+    "yuyake"
+  ]
+}


### PR DESCRIPTION
## 変更内容: #330対応：code spell checkerで `omesis` がスペルミス扱いにならないように変更

code spell checkerで `omesis` がスペルミス扱いになってしまうという現象がありました。

詳しくは #330 に記載しました。
https://github.com/omegasisters/homepage/issues/330

 `.vscode` フォルダに設定ファイル `cspell.json` を追加することで解決しました。


## 確認事項: Check point

<!-- PRを作成するとチェックボックスになります、もしくは [x] にするとチェック状態になります。 -->

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
  - 最新の master を取り込む方法
    - upstream に fork 元リポジトリを追加
      - `git remote add upstream git@github.com:omegasisters/homepage.git`
    - 現在のブランチに `upstream` の `master` を取り込む
      - `$ git pull --rebase upstream master`
  - おまけ
    - rebase 後に再度 `push` する場合、 `--force-with-lease` オプションをつける
      - `git push --force-with-lease origin <ブランチ名>`
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。
- [x] Pull Request に関連した issue の URL を貼り付けた

## 補足: Other Information

<!-- レビューをする際に特に見てほしい点、懸念・注意点、など 画像とかあるとわかりやすいかも！ -->
