### PR TITLE
言語スイッチの位置変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,16 @@ MMMMMMMMMMMMMMMMMMMMMMMMMNNmaggkwkkXuuVVXuuXXkkXuuZuXVuVCXwkwQggggNNMMMMMMMMMMMM
           <ul id="header_contents" class="drawer-menu">
             <!--      各項目へのジャンプ用ヘッダです。-->
             <!--      section_titleクラスを付与したh2要素をジャンプ用タイトルとして使用する想定です。-->
+            <li class="drawer-dropdown">
+              <a
+                class="drawer-menu-item not-closed-menu-item"
+                data-toggle="dropdown"
+                role="button"
+                aria-expanded="false"
+                >Language<span class="drawer-caret"></span
+              ></a>
+              <ul id="preact-i18n" class="drawer-dropdown-menu"></ul>
+            </li>
             <li>
               <a
                 id="header_section_description"
@@ -218,16 +228,6 @@ MMMMMMMMMMMMMMMMMMMMMMMMMNNmaggkwkkXuuVVXuuXXkkXuuZuXVuVCXwkwQggggNNMMMMMMMMMMMM
                 rel="noopener noreferrer"
                 >お問い合わせ</a
               >
-            </li>
-            <li class="drawer-dropdown">
-              <a
-                class="drawer-menu-item not-closed-menu-item"
-                data-toggle="dropdown"
-                role="button"
-                aria-expanded="false"
-                >Language<span class="drawer-caret"></span
-              ></a>
-              <ul id="preact-i18n" class="drawer-dropdown-menu"></ul>
             </li>
           </ul>
         </nav>

--- a/pages/alpha.html
+++ b/pages/alpha.html
@@ -80,10 +80,6 @@
     </title>
   </head>
   <body class="drawer drawer--top drawer--navbarTopGutter">
-    <div
-      style="position: fixed;z-index: 9999;left: 1rem;top: 1rem;"
-      id="preact-i18n"
-    ></div>
     <header class="drawer-navbar drawer-navbar--fixed" role="banner">
       <div class="drawer-container">
         <div class="drawer-navbar-header">
@@ -96,6 +92,16 @@
           <ul id="header_contents" class="drawer-menu drawer-menu--right">
             <!--      各項目へのジャンプ用ヘッダです。-->
             <!--      section_titleクラスを付与したh2要素をジャンプ用タイトルとして使用する想定です。-->
+            <li class="drawer-dropdown">
+              <a
+                class="drawer-menu-item not-closed-menu-item"
+                data-toggle="dropdown"
+                role="button"
+                aria-expanded="false"
+                >Language<span class="drawer-caret"></span
+              ></a>
+              <ul id="preact-i18n" class="drawer-dropdown-menu"></ul>
+            </li>
             <li>
               <a class="drawer-menu-item" href="#section_description"
                 >あるブラって？</a
@@ -208,6 +214,10 @@
     ></script>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/iScroll/5.2.0/iscroll.min.js"
+      defer
+    ></script>
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"
       defer
     ></script>
     <script


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- This is just a template. You don't have to follow -->

<!-- タイトルは変更の内容が他の人にも伝わるように1行でまとめる。 -->

## 変更内容: Summary

<!-- 何故変更したか、これが取り込まれると何が嬉しいか、何が解決されるのか、など詳細な内容を記載 -->
スイッチの位置がが下過ぎて一部Android端末だと選択肢を選べなくなってた。
![Screenshot from 2020-01-22 00-18-43](https://user-images.githubusercontent.com/16427740/72819006-caf1a980-3caf-11ea-87f1-aadcfc4139d3.png)

なので、スイッチの位置を一番上に持ってきた。
![Screenshot from 2020-01-22 00-37-13](https://user-images.githubusercontent.com/16427740/72819081-eeb4ef80-3caf-11ea-8f23-39079b903c24.png)

ついでにアルブラのページの分も直しました。

## 確認事項: Check point

<!-- PRを作成するとチェックボックスになります、もしくは [x] にするとチェック状態になります。 -->

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
  - 最新の master を取り込む方法
    - upstream に fork 元リポジトリを追加
      - `git remote add upstream git@github.com:omegasisters/homepage.git`
    - 現在のブランチに `upstream` の `master` を取り込む
      - `$ git pull --rebase upstream master`
  - おまけ
    - rebase 後に再度 `push` する場合、 `--force-with-lease` オプションをつける
      - `git push --force-with-lease origin <ブランチ名>`
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。
- [x] Pull Request に関連した issue の URL を貼り付けた

## 補足: Other Information

<!-- レビューをする際に特に見てほしい点、懸念・注意点、など 画像とかあるとわかりやすいかも！ -->
