### PR TITLE
画面サイズによってヘッダーが2列になってしまうのを修正

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -84,31 +84,26 @@ header.scrolled {
 /* shrink header menu item... */
 @media screen and (max-width: 83em) {
   header a.drawer-menu-item {
-    color: white;
     font-size: 0.72em;
   }
 }
 @media screen and (max-width: 75em) {
   header a.drawer-menu-item {
-    color: white;
     font-size: 0.65em;
   }
 }
 @media screen and (max-width: 70em) {
   header a.drawer-menu-item {
-    color: white;
     font-size: 0.58em;
   }
 }
 @media screen and (max-width: 1024px) {
   header a.drawer-menu-item {
-    color: white;
     font-size: 0.5em;
   }
 }
 @media screen and (max-width: 1023px) {
   header a.drawer-menu-item {
-    color: white;
     font-size: 1em;
   }
 }

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -100,10 +100,16 @@ header.scrolled {
     font-size: 0.58em;
   }
 }
-@media screen and (max-width: 64em) {
+@media screen and (max-width: 1024px) {
   header a.drawer-menu-item {
     color: white;
     font-size: 0.5em;
+  }
+}
+@media screen and (max-width: 1023px) {
+  header a.drawer-menu-item {
+    color: white;
+    font-size: 1em;
   }
 }
 

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -81,6 +81,31 @@ header.scrolled {
     transition-duration: 0.5s;
   }
 }
+/* shrink header menu item... */
+@media screen and (max-width: 83em) {
+  header a.drawer-menu-item {
+    color: white;
+    font-size: 0.72em;
+  }
+}
+@media screen and (max-width: 75em) {
+  header a.drawer-menu-item {
+    color: white;
+    font-size: 0.65em;
+  }
+}
+@media screen and (max-width: 70em) {
+  header a.drawer-menu-item {
+    color: white;
+    font-size: 0.58em;
+  }
+}
+@media screen and (max-width: 64em) {
+  header a.drawer-menu-item {
+    color: white;
+    font-size: 0.5em;
+  }
+}
 
 header a.drawer-menu-item {
   color: white;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->
<!-- This is just a template. You don't have to follow -->

<!-- タイトルは変更の内容が他の人にも伝わるように1行でまとめる。 -->

## 変更内容: Summary
https://github.com/omegasisters/homepage/issues/342
画面サイズによってはヘッダーが2列になってしまう問題を取り急ぎ修正しました。
あんまりきれいじゃないですが…小さくなりすぎないように徐々に文字サイズを小さくして対応してます。
そもそもヘッダーメニューが多すぎ問題な気も。。
![image](https://user-images.githubusercontent.com/20788898/72906597-d3acb300-3d75-11ea-9560-7faf03131280.png)
![image](https://user-images.githubusercontent.com/20788898/72906655-e45d2900-3d75-11ea-9e2e-ed6edf83c80c.png)
![image](https://user-images.githubusercontent.com/20788898/72906681-f343db80-3d75-11ea-8e48-df3a1bc57284.png)
![image](https://user-images.githubusercontent.com/20788898/72906736-00f96100-3d76-11ea-9704-e06cc5a51e18.png)
![image](https://user-images.githubusercontent.com/20788898/72906805-21c1b680-3d76-11ea-99ce-cf617d9462f0.png)


<!-- 何故変更したか、これが取り込まれると何が嬉しいか、何が解決されるのか、など詳細な内容を記載 -->

## 確認事項: Check point

<!-- PRを作成するとチェックボックスになります、もしくは [x] にするとチェック状態になります。 -->

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
  - 最新の master を取り込む方法
    - upstream に fork 元リポジトリを追加
      - `git remote add upstream git@github.com:omegasisters/homepage.git`
    - 現在のブランチに `upstream` の `master` を取り込む
      - `$ git pull --rebase upstream master`
  - おまけ
    - rebase 後に再度 `push` する場合、 `--force-with-lease` オプションをつける
      - `git push --force-with-lease origin <ブランチ名>`
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。
- [x] Pull Request に関連した issue の URL を貼り付けた

## 補足: Other Information

<!-- レビューをする際に特に見てほしい点、懸念・注意点、など 画像とかあるとわかりやすいかも！ -->
