### PR TITLE
:cat2::dash: モバイルサイズでTwitter widgetがはみ出していた問題を修正しました

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -995,29 +995,32 @@ a.share-button:hover {
 .pr_announce {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: space-evenly;
   align-items: flex-start;
 
   margin-top: 20px;
   padding: 1vw;
   background-color: rgba(0, 0, 0, 0.2);
   border-radius: 1vw;
-  width: 1200px;
-}
-@media screen and (max-width: 1300px) {
-  .pr_announce {
-    width: 90%;
-  }
-}
-@media screen and (max-width: 600px) {
-  .pr_announce {
-    width: 600px;
-  }
+  width: 100%;
+  max-width: 1200px;
 }
 
 .pr_announce_item {
-  margin-left: 5px;
-  margin-right: 5px;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+@media screen and (min-width: 768px) {
+  .pr_announce_item {
+    width: 50%;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .pr_announce_item {
+    width: auto;
+  }
 }
 
 @keyframes unchan-show-toguro {

--- a/index.html
+++ b/index.html
@@ -545,7 +545,7 @@ MMMMMMMMMMMMMMMMMMMMMMMMMNNmaggkwkkXuuVVXuuXXkkXuuZuXVuVCXwkwQggggNNMMMMMMMMMMMM
         </div>
         <div class="pr_announce">
           <div class="pr_announce_item">
-            <blockquote class="twitter-tweet" data-dnt="true">
+            <blockquote class="twitter-tweet" data-dnt="true" data-width="100%">
               <p lang="ja" dir="ltr">
                 おめシスのホームページをGithubのプルリクで更新していったらどうなるのか、こっそり検証中です。そのうち動画にします！<a
                   href="https://t.co/rErhv32NNR"
@@ -560,7 +560,7 @@ MMMMMMMMMMMMMMMMMMMMMMMMMNNmaggkwkkXuuVVXuuXXkkXuuZuXVuVCXwkwQggggNNMMMMMMMMMMMM
             </blockquote>
           </div>
           <div class="pr_announce_item">
-            <blockquote class="twitter-tweet" data-dnt="true">
+            <blockquote class="twitter-tweet" data-dnt="true" data-width="100%">
               <p lang="ja" dir="ltr">
                 １ヶ月間、GitHubのプルリクだけでホームページを作った結果…！？<a
                   href="https://t.co/hCtBVhrHxs"


### PR DESCRIPTION
## 変更内容: Summary

埋め込んだTwitter widgetの幅が固定されていて画面サイズが小さい時に横スクロールが発生する状態になっていたのを画面サイズ内に収まるように修正しました。
合わせて少し小さめの画面サイズでも 2 column で表示されるように調整しました。

**before <--------> after :rabbit:**  
![before](https://user-images.githubusercontent.com/1486999/73181104-f6660f80-4159-11ea-971a-77d431c7d4a5.png)


## 確認事項: Check point

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
  - 最新の master を取り込む方法
    - upstream に fork 元リポジトリを追加
      - `git remote add upstream git@github.com:omegasisters/homepage.git`
    - 現在のブランチに `upstream` の `master` を取り込む
      - `$ git pull --rebase upstream master`
  - おまけ
    - rebase 後に再度 `push` する場合、 `--force-with-lease` オプションをつける
      - `git push --force-with-lease origin <ブランチ名>`
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。
- [x] ~~Pull Request に関連した issue の URL を貼り付けた~~

## 補足: Other Information
