### PR TITLE
グローバルメニューのフォントサイズを調整しました。

### DIFF
--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -33,7 +33,6 @@ body.drawer--navbarTopGutter {
 header.drawer-navbar .drawer-navbar-header {
   background-color: rgba(0, 0, 0, 0);
   border-bottom: none;
-  padding: 0 1.5rem;
 }
 
 header.drawer-navbar {
@@ -69,11 +68,21 @@ header.scrolled {
     border: solid 3px rgba(255, 255, 255, 0.2);
   }
 
+  header .drawer-navbar-header {
+    padding: 0 1.5rem;
+    z-index: unset;
+  }
+
   header .drawer-hamburger {
     padding: 0;
     height: 3.75rem;
     position: relative;
     margin-left: auto;
+  }
+
+  header.drawer-navbar .drawer-nav {
+    padding-top: 0;
+    z-index: 3;
   }
 
   div.drawer-overlay {
@@ -85,30 +94,32 @@ header.scrolled {
     transition-duration: 0.5s;
   }
 }
+
 /* shrink header menu item... */
 
 header a.drawer-menu-item {
-  font-size: 0.72em;
+  font-size: 0.8em;
 }
 
-@media screen and (max-width: 84em) {
+@media screen and (min-width: 64em) {
+  /*override drawer*/
+  header.drawer-navbar .drawer-menu {
+    display: flex;
+    justify-content: space-evenly;
+  }
+
+  header.drawer-navbar .drawer-menu > li {
+    float: none;
+  }
+
   header a.drawer-menu-item {
-    font-size: 0.65em;
+    font-size: 1.2vw;
   }
 }
-@media screen and (max-width: 78em) {
+
+@media screen and (min-width: 84em) {
   header a.drawer-menu-item {
-    font-size: 0.58em;
-  }
-}
-@media screen and (max-width: 1153px) {
-  header a.drawer-menu-item {
-    font-size: 0.5em;
-  }
-}
-@media screen and (max-width: 1046px) {
-  header a.drawer-menu-item {
-    font-size: 0.48em;
+    font-size: 0.78em;
   }
 }
 


### PR DESCRIPTION
## :rabbit: 変更内容: Summary

メニュー項目が増え特にモバイル時にフォントサイズが余りにも小さくなってしまっていたため、文字サイズを調整しました。
合わせてメニューの文字サイズの調整が複雑になCSSになってしまっていたので、PCサイズではメニューが固定幅になるまではでは `vw`  でフォントサイズをレスポンシブになるように指定しました。

> `vw`: 1% of the viewport's width  
> https://developer.mozilla.org/ja/docs/Learn/CSS/Building_blocks/Values_and_units

##### :sparkles: before <-----> after

![nav-mb](https://user-images.githubusercontent.com/1486999/74301008-06563400-4d95-11ea-9305-c40e0b61cb31.png)

※ `z-index` を調整してあるので、Ωメニュー開閉ボタンタップ可能です

![omesis_global_nav](https://user-images.githubusercontent.com/1486999/74301353-33571680-4d96-11ea-8c61-1754a41cbd49.gif)


## :sunglasses: 確認事項: Check point

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
  - 最新の master を取り込む方法
    - upstream に fork 元リポジトリを追加
      - `git remote add upstream git@github.com:omegasisters/homepage.git`
    - 現在のブランチに `upstream` の `master` を取り込む
      - `$ git pull --rebase upstream master`
  - おまけ
    - rebase 後に再度 `push` する場合、 `--force-with-lease` オプションをつける
      - `git push --force-with-lease origin <ブランチ名>`
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。
- ~~[ ] Pull Request に関連した issue の URL を貼り付けた~~

## :poop: 補足: Other Information