### PR TITLE
:cactus: webpack dev-server の root を /homepage にしました

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -70,7 +70,7 @@ yarn install
 
 ### Local preview
 
-When you run the command, you can see http://localhost:8080
+When you run the command, you can see http://localhost:8080/homepage/
 
 ```
 yarn start

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ yarn install
 
 ### ローカルプレビュー
 
-コマンドを実行すると、 http://localhost:8080 にホストされます
+コマンドを実行すると、 http://localhost:8080/homepage/ にホストされます
 
 ```
 yarn start

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,9 @@ module.exports = (env) => ({
     publicPath: '/assets/preact_build/',
     disableHostCheck: true,
     historyApiFallback: true,
+    contentBase: path.join(__dirname, '/'),
+    contentBasePublicPath: '/homepage',
+    openPage: 'homepage',
   },
   performance: {
     hints: false,


### PR DESCRIPTION
## :beetle: 変更内容: Summary

開発サーバー (`localhost:8080`) で 【初心者向け】すごい面白い動画 の json が読み込まれず、表示されない問題を修正しました。

https://github.com/omegasisters/homepage/blob/939b5a8abb878f716a1da09f76bbaceb3185e9fc/assets/js/ytplaylist.js#L2

開発サーバーの root は `/homepage` ではなく、動画リストの読み込みは `/homepage` のパスで fetch していたためにパスが異なり json が読み込めていない状態となっていました。
そこで下記修正を行いました。
副作用として、本サイトと同様に `/homepage` でパスを指定することができるようになりました :tada:

1. `yarn start` で起動する dev server の root を実際のサイトど同じ `/homepage` に変更
1. `yarn start` でデフォルトで `localhost:8080/homepage/` が開くように変更

ref. https://github.com/omegasisters/homepage/issues/374 
fixed https://github.com/omegasisters/homepage/issues/231

cf. https://webpack.js.org/configuration/dev-server/#devservercontentbasepublicpath

## :sunglasses: 確認事項: Check point

- [x] PR を作成する前に、 https://github.com/omegasisters/homepage の最新の master を取り込み済みである。
  - Conflict や他の方の変更で自分の変更が動かなくなる可能性を防ぎます。
  - 最新の master を取り込む方法
    - upstream に fork 元リポジトリを追加
      - `git remote add upstream git@github.com:omegasisters/homepage.git`
    - 現在のブランチに `upstream` の `master` を取り込む
      - `$ git pull --rebase upstream master`
  - おまけ
    - rebase 後に再度 `push` する場合、 `--force-with-lease` オプションをつける
      - `git push --force-with-lease origin <ブランチ名>`
- [x] 動作確認済みである。
  - 何らかの理由で本番に取り込まれるまで確認できない場合はその旨を補足に記載する。
- [x] prettier によるコード整形を行った、もしくは画面に関係ない変更である。
  - 可能な方のみで良いと思いますが、意図せず他の方がフォーマットするとコード差分が増えすぎるので自分の分は自分でやるのがよろしいかと思います。
- [x] スマホ（狭い画角）でも表示を確認した、もしくは画面に関係ない変更である。
- [x] 他の方の変更を意図せず削除・変更していないか、差分をもう一度確認した。
- [x] 破壊的な変更を行った場合、影響範囲をもう一度確認した。もしくは破壊的な変更を行っていない。
- dev-server での動作確認
  - [x] あるふぁブラザーズ ページ確認
  - [x] おめが診断が動作することを確認
  - [x] 言語切替が問題なく動作することを確認
- [x] Pull Request に関連した issue の URL を貼り付けた

## :rabbit: 補足: Other Information

dev-server なので本番環境への影響はありません。
また相対パスで指定されている箇所に関しては問題はないと思います。
他絶対パスで指定されている部分がなければ local 環境での動作も大丈夫な筈…ﾃﾞｽ
